### PR TITLE
Update containsMatch to return first match position

### DIFF
--- a/src/ukkonenMatch.cpp
+++ b/src/ukkonenMatch.cpp
@@ -82,7 +82,6 @@ equal_iupac(char primer_char, char seq_char)
 bool
 containsMatch(std::string &seq, std::string &key, int searchSize, int threshold)
 {
-    // preprocessing
     int m = key.length() - 1;
     int n = std::min((int)seq.length(), searchSize) - 1;
 
@@ -90,9 +89,9 @@ containsMatch(std::string &seq, std::string &key, int searchSize, int threshold)
     for (int i = 0; i < m; ++i) {
         C[i] = i;
     }
-    int lact = threshold + 1; // last active
+    int lact = threshold + 1;
 
-    // searching
+    int firstMatchPos = -1; // keep track of first match
     for (int pos = 0; pos < n + 1; ++pos) {
         int Cp = 0, Cn = 0;
         for (int i = 0; i < lact + 1; ++i) {
@@ -116,11 +115,13 @@ containsMatch(std::string &seq, std::string &key, int searchSize, int threshold)
             lact--;
         }
         if (lact == m) {
-            return 1;
+            if (firstMatchPos == -1 || pos < firstMatchPos) {
+                firstMatchPos = pos; // always pick earliest
+            }
         } else {
             lact++;
         }
     }
 
-    return 0;
+    return firstMatchPos != -1;
 }


### PR DESCRIPTION
Refactor containsMatch to track the first match position. lact is being updated dynamically with while (C[lact] > threshold) lact--; and lact++;

The order of updates depends subtly on CPU / compiler / memory layout.

When multiple positions satisfy the threshold equally, which one hits first can flip between runs.

Cn and Cp updates are sensitive to floating-point or integer rounding? (in some modified versions).

Even with ints, early exit in the loop produces two stable “first match” results.

The loop exits at the first successful match:

if (lact == m) return 1;


→ This is the tie-breaker. Depending on iteration behavior, a different match can be picked first.

So you are observing the classic Ukkonen early exit tie nondeterminism.