### PR TITLE
Fix out-of-bounds access in Levenshtein edit distance 

### DIFF
--- a/src/ukkonenMatch.cpp
+++ b/src/ukkonenMatch.cpp
@@ -86,7 +86,7 @@ containsMatch(std::string &seq, std::string &key, int searchSize, int threshold)
     int m = key.length() - 1;
     int n = std::min((int)seq.length(), searchSize) - 1;
 
-    std::vector<int> C(m, 0);
+    std::vector<int> C(m + 1, 0);
     for (int i = 0; i < m; ++i) {
         C[i] = i;
     }

--- a/src/ukkonenMatch.cpp
+++ b/src/ukkonenMatch.cpp
@@ -1,5 +1,6 @@
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "ukkonenMatch.h"
 
@@ -85,7 +86,7 @@ containsMatch(std::string &seq, std::string &key, int searchSize, int threshold)
     int m = key.length() - 1;
     int n = std::min((int)seq.length(), searchSize) - 1;
 
-    int C[m];
+    std::vector<int> C(m, 0);
     for (int i = 0; i < m; ++i) {
         C[i] = i;
     }


### PR DESCRIPTION
Fix out-of-bounds access in Levenshtein edit distance by using vector C of size m rather than array. (Vectors have certain extra memory overhead and allow for easier resizing or bounds checking).

Prev C[m] array size is m (0...m-1)
in the loop, C[lact] when lact == m or C[i] when lact == m, will trigger out of bound value leads to oscillation between 2 stable outcome due to neg value < threshold


Example debugging trace data before bug fix
Barcode size = 15, pos 812 trigger a false match due to C[m] out of bound (~50% as neg value) < threshold

    pos=808, lact=10, m=14, C[lact]=2, threshold=2, C[m]=-9701813
    pos=809, lact=11, m=14, C[lact]=2, threshold=2, C[m]=-9701813
    pos=810, lact=12, m=14, C[lact]=2, threshold=2, C[m]=-9701813
    pos=811, lact=13, m=14, C[lact]=2, threshold=2, C[m]=-9701813
    pos=812, lact=14, m=14, C[lact]=-9701812, threshold=2, C[m]=-9701812
    pos=813, lact=14, m=14, C[lact]=3, threshold=2, C[m]=3
    pos=814, lact=2, m=14, C[lact]=3, threshold=2, C[m]=3
    pos=815, lact=2, m=14, C[lact]=2, threshold=2, C[m]=3
    pos=816, lact=3, m=14, C[lact]=2, threshold=2, C[m]=3

The other 50%, the out of bound report a large positive value and pos 812 is not matched.

    pos=809, lact=11, m=14, C[lact]=2, threshold=2, C[m]=1246254667
    pos=810, lact=12, m=14, C[lact]=2, threshold=2, C[m]=1246254667
    pos=811, lact=13, m=14, C[lact]=2, threshold=2, C[m]=1246254667
    pos=812, lact=14, m=14, C[lact]=3, threshold=2, C[m]=3
    pos=813, lact=3, m=14, C[lact]=3, threshold=2, C[m]=3
    pos=814, lact=2, m=14, C[lact]=3, threshold=2, C[m]=3
    pos=815, lact=2, m=14, C[lact]=2, threshold=2, C[m]=3

After bug fix, C[m] out of bound issue is resolved

    pos=809, lact=11, m=14, C[lact]=2, threshold=2, C[m]=3
    pos=810, lact=12, m=14, C[lact]=2, threshold=2, C[m]=3
    pos=811, lact=13, m=14, C[lact]=2, threshold=2, C[m]=3
    pos=812, lact=14, m=14, C[lact]=3, threshold=2, C[m]=3
    pos=813, lact=3, m=14, C[lact]=3, threshold=2, C[m]=3
    pos=814, lact=2, m=14, C[lact]=3, threshold=2, C[m]=3
    pos=815, lact=2, m=14, C[lact]=2, threshold=2, C[m]=3
