### PR TITLE
update json output

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,6 +82,14 @@ main(int argc, char ** argv)
         stats.total++;
         stats.strand.stats[record.strand]++;
         stats.artefact.stats[record.artefact]++;
+
+        if (artefact::getName(record.artefact) == "no artefact") {
+            stats.breakdown.noArtefactStrand[record.strand]++;
+            stats.breakdown.noArtefactTotal++;
+        } else {
+            stats.breakdown.artefactTypes[record.artefact]++;
+            stats.breakdown.artefactTotal++;
+        }
     }
 
     if (!config.silent) {

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -28,9 +28,28 @@ namespace stats {
     toJson(Stats stats)
     {
         nlohmann::json json;
+        json["artefactBreakdown"] = toJson(stats.breakdown);
         json["totalReads"] = stats.total;
-        json["strandStats"] = toJson(stats.strand);
-        json["artefactStats"] = toJson(stats.artefact);
+
+        return json;
+    }
+
+    nlohmann::json
+    toJson(ArtefactBreakdown breakdown)
+    {
+        nlohmann::json json;
+        for (const auto& [strand, count] : breakdown.noArtefactStrand) {
+            json["no artefact"][std::string(1, strand)] = count;
+        }
+        json["no artefact"]["total"] = breakdown.noArtefactTotal;
+
+        nlohmann::json artefactJson;
+        for (const auto& [key, count] : breakdown.artefactTypes) {
+            artefactJson[artefact::getName(key)] = count;
+        }
+        artefactJson["total"] = breakdown.artefactTotal;
+
+        json["artefact"] = artefactJson;
 
         return json;
     }

--- a/src/stats.h
+++ b/src/stats.h
@@ -25,6 +25,17 @@ namespace stats {
         std::unordered_map<artefact::Artefact, int> stats;
     };
 
+    struct ArtefactBreakdown
+    {
+        // strand counts when there is NO artefact
+        std::unordered_map<strand::Strand, int> noArtefactStrand;
+
+        // counts of specific artefact types (TSO-TSO, RTP-RTP)
+        std::unordered_map<artefact::Artefact,int> artefactTypes;
+
+        int noArtefactTotal = 0;
+        int artefactTotal = 0;
+    };
     /*
         holds all the necessary stats about the reads in the file being parsed
     */
@@ -33,6 +44,7 @@ namespace stats {
         int total;
         StrandStats strand;
         ArtefactStats artefact;
+        ArtefactBreakdown breakdown;
     };
 
     nlohmann::json
@@ -44,6 +56,8 @@ namespace stats {
     nlohmann::json
     toJson(Stats stats);
 
+    nlohmann::json
+    toJson(ArtefactBreakdown stats);
 }
 
 #endif


### PR DESCRIPTION
It was unclear for me if the unknown group contain the artefact counts (theoretically it does).
9 is the prev format, and 2 artefact. But for user is unclear is the 2 artefact are counted within the 9 unknown.

Previous json format example
<img width="307" height="275" alt="Screenshot 2025-12-22 at 11 58 30 AM" src="https://github.com/user-attachments/assets/53b76978-7d00-4e29-b729-f3f60628a6ab" />

New json format, clearly shows the breakdown for user.
<img width="314" height="344" alt="Screenshot 2025-12-22 at 11 54 00 AM" src="https://github.com/user-attachments/assets/91ad18fe-ccc5-4e37-9023-398a5403802a" />